### PR TITLE
ssh: sshfs => asyncssh

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ python_requires= >=3.4
 include_package_data=True
 packages=find:
 [options.extras_require]
-ssh=sshfs>=2021.7.1
+ssh=asyncssh
 [options.entry_points]
 console_scripts=
     tpi=tpi.main:main


### PR DESCRIPTION
The code only makes reference to `asyncssh` so there doesn't seem to be any need to depend on `sshfs`