### PR TITLE
Migrate from PyPI tokens to Trusted Publishers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,10 @@ jobs:
   deploy:
     name: PyPI Deploy
     needs: [check, test]
+    environment: pypi
+    permissions:
+      contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -66,8 +70,9 @@ jobs:
       with:
         requirements: twine setuptools wheel setuptools_scm[toml]
         build: true
-        password: ${{ secrets.PYPI_TOKEN }}
-        upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+        upload: false
+    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
     - id: meta
       name: Changelog
       run: |


### PR DESCRIPTION
https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers#using-trusted-publishing-with-github-actions